### PR TITLE
Fix delete booking

### DIFF
--- a/app/api/v1/bookings/[bookingId]/route.ts
+++ b/app/api/v1/bookings/[bookingId]/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@/server/api.utils.server";
 import { ResponseCodesConstants } from "@/src/constants";
 import { deepMerge } from "@/src/utils/common.utils";
-import { getPostgresTimestamp } from "@/src/utils/date.utils";
+import { dateDiff, getPostgresTimestamp } from "@/src/utils/date.utils";
 import { BookingI } from "@/src/types/booking.types";
 import { RolesEnum } from "@/src/enums/roles.enums";
 import {
@@ -264,6 +264,18 @@ export async function PUT(
           service_date: updatedBooking.service_date,
           duration_hours: updatedBooking.duration_hours,
           notes: updatedBooking.notes,
+          status: updatedBooking.status,
+        };
+      }
+      if (
+        booking.status === BookingStatusEnum.CONFIRMED &&
+        dateDiff(booking.endDate, new Date()) > 24
+      ) {
+        allowedUpdates = {
+          service_date: updatedBooking.service_date,
+          duration_hours: updatedBooking.duration_hours,
+          notes: updatedBooking.notes,
+          status: updatedBooking.status,
         };
       }
 

--- a/components/bookings/bookingCard.component.tsx
+++ b/components/bookings/bookingCard.component.tsx
@@ -236,7 +236,6 @@ const BookingCardComponent = (props: BookingCardComponentI) => {
               </span>
               <Badge
                 label={
-                  // Se lo stato è finale, mostro lo stato della prenotazione
                   [
                     BookingStatusEnum.CANCELLED,
                     BookingStatusEnum.REFUNDED,
@@ -245,15 +244,13 @@ const BookingCardComponent = (props: BookingCardComponentI) => {
                     ? BookingUtils.getStatusText(
                         booking.status as BookingStatusEnum
                       )
-                    : // Altrimenti controllo il pagamento
-                      booking.payment_status === PaymentStatusEnum.PAID
+                    : booking.payment_status === PaymentStatusEnum.PAID
                       ? BookingUtils.getStatusText(
                           booking.status as BookingStatusEnum
                         )
                       : "Da pagare"
                 }
                 color={
-                  // Se lo stato è finale, uso il colore dello stato
                   [
                     BookingStatusEnum.CANCELLED,
                     BookingStatusEnum.REFUNDED,
@@ -262,8 +259,7 @@ const BookingCardComponent = (props: BookingCardComponentI) => {
                     ? BookingUtils.getStatusColor(
                         booking.status as BookingStatusEnum
                       )
-                    : // Altrimenti controllo il pagamento
-                      booking.payment_status === PaymentStatusEnum.PAID
+                    : booking.payment_status === PaymentStatusEnum.PAID
                       ? BookingUtils.getStatusColor(
                           booking.status as BookingStatusEnum
                         )

--- a/components/bookings/bookingCard.component.tsx
+++ b/components/bookings/bookingCard.component.tsx
@@ -147,21 +147,18 @@ const BookingCardComponent = (props: BookingCardComponentI) => {
   return (
     <Link
       href={BookingUtils.getBookingDetailsUrl(booking.id)}
-      className="no-underline"
-    >
+      className="no-underline">
       <Card>
         <div
           className={clsx(
             isVigil && "flex flex-col gap-1",
             isConsumer && "flex gap-1 "
-          )}
-        >
+          )}>
           <div
             className={clsx(
               isVigil && "flex items-start gap-2",
               isConsumer && "inline-flex items-center flex-nowrap gap-2"
-            )}
-          >
+            )}>
             <Avatar
               size="big"
               userId={getUserInfo()?.id}
@@ -239,18 +236,38 @@ const BookingCardComponent = (props: BookingCardComponentI) => {
               </span>
               <Badge
                 label={
-                  booking?.payment_status === PaymentStatusEnum.PAID
+                  // Se lo stato è finale, mostro lo stato della prenotazione
+                  [
+                    BookingStatusEnum.CANCELLED,
+                    BookingStatusEnum.REFUNDED,
+                    BookingStatusEnum.COMPLETED,
+                  ].includes(booking.status as BookingStatusEnum)
                     ? BookingUtils.getStatusText(
                         booking.status as BookingStatusEnum
                       )
-                    : "Da pagare"
+                    : // Altrimenti controllo il pagamento
+                      booking.payment_status === PaymentStatusEnum.PAID
+                      ? BookingUtils.getStatusText(
+                          booking.status as BookingStatusEnum
+                        )
+                      : "Da pagare"
                 }
                 color={
-                  booking?.payment_status === PaymentStatusEnum.PAID
+                  // Se lo stato è finale, uso il colore dello stato
+                  [
+                    BookingStatusEnum.CANCELLED,
+                    BookingStatusEnum.REFUNDED,
+                    BookingStatusEnum.COMPLETED,
+                  ].includes(booking.status as BookingStatusEnum)
                     ? BookingUtils.getStatusColor(
                         booking.status as BookingStatusEnum
                       )
-                    : "yellow"
+                    : // Altrimenti controllo il pagamento
+                      booking.payment_status === PaymentStatusEnum.PAID
+                      ? BookingUtils.getStatusColor(
+                          booking.status as BookingStatusEnum
+                        )
+                      : "yellow"
                 }
               />
             </div>

--- a/components/bookings/bookingDetails.component.tsx
+++ b/components/bookings/bookingDetails.component.tsx
@@ -167,18 +167,38 @@ const BookingDetailsComponent = (props: BookingDetailsComponentI) => {
         <span className="absolute top-0 right-0">
           <Badge
             label={
-              booking?.payment_status === PaymentStatusEnum.PAID
+              // Se lo stato è finale, mostro lo stato della prenotazione
+              [
+                BookingStatusEnum.CANCELLED,
+                BookingStatusEnum.REFUNDED,
+                BookingStatusEnum.COMPLETED,
+              ].includes(booking.status as BookingStatusEnum)
                 ? BookingUtils.getStatusText(
                     booking.status as BookingStatusEnum
                   )
-                : "Da pagare"
+                : // Altrimenti controllo il pagamento
+                  booking.payment_status === PaymentStatusEnum.PAID
+                  ? BookingUtils.getStatusText(
+                      booking.status as BookingStatusEnum
+                    )
+                  : "Da pagare"
             }
             color={
-              booking?.payment_status === PaymentStatusEnum.PAID
+              // Se lo stato è finale, uso il colore dello stato
+              [
+                BookingStatusEnum.CANCELLED,
+                BookingStatusEnum.REFUNDED,
+                BookingStatusEnum.COMPLETED,
+              ].includes(booking.status as BookingStatusEnum)
                 ? BookingUtils.getStatusColor(
                     booking.status as BookingStatusEnum
                   )
-                : "yellow"
+                : // Altrimenti controllo il pagamento
+                  booking.payment_status === PaymentStatusEnum.PAID
+                  ? BookingUtils.getStatusColor(
+                      booking.status as BookingStatusEnum
+                    )
+                  : "yellow"
             }
           />
         </span>
@@ -220,7 +240,8 @@ const BookingDetailsComponent = (props: BookingDetailsComponentI) => {
                 {dateDisplay(booking.startDate, "dateTime")}
               </p>
               <p>
-                <span className="font-medium">Indirizzo del servizio:</span>&nbsp;
+                <span className="font-medium">Indirizzo del servizio:</span>
+                &nbsp;
                 {capitalize(booking.address)}
               </p>
               <p>

--- a/components/bookings/bookingDetails.component.tsx
+++ b/components/bookings/bookingDetails.component.tsx
@@ -167,7 +167,6 @@ const BookingDetailsComponent = (props: BookingDetailsComponentI) => {
         <span className="absolute top-0 right-0">
           <Badge
             label={
-              // Se lo stato è finale, mostro lo stato della prenotazione
               [
                 BookingStatusEnum.CANCELLED,
                 BookingStatusEnum.REFUNDED,
@@ -176,15 +175,13 @@ const BookingDetailsComponent = (props: BookingDetailsComponentI) => {
                 ? BookingUtils.getStatusText(
                     booking.status as BookingStatusEnum
                   )
-                : // Altrimenti controllo il pagamento
-                  booking.payment_status === PaymentStatusEnum.PAID
+                : booking.payment_status === PaymentStatusEnum.PAID
                   ? BookingUtils.getStatusText(
                       booking.status as BookingStatusEnum
                     )
                   : "Da pagare"
             }
             color={
-              // Se lo stato è finale, uso il colore dello stato
               [
                 BookingStatusEnum.CANCELLED,
                 BookingStatusEnum.REFUNDED,
@@ -193,8 +190,7 @@ const BookingDetailsComponent = (props: BookingDetailsComponentI) => {
                 ? BookingUtils.getStatusColor(
                     booking.status as BookingStatusEnum
                   )
-                : // Altrimenti controllo il pagamento
-                  booking.payment_status === PaymentStatusEnum.PAID
+                : booking.payment_status === PaymentStatusEnum.PAID
                   ? BookingUtils.getStatusColor(
                       booking.status as BookingStatusEnum
                     )

--- a/src/utils/booking.utils.ts
+++ b/src/utils/booking.utils.ts
@@ -141,16 +141,19 @@ export const BookingUtils = {
         return true;
       }
 
-      if (userRole === RolesEnum.CONSUMER) {
+      if (
+        userRole === RolesEnum.CONSUMER &&
+        booking.status === BookingStatusEnum.CONFIRMED
+      ) {
         const now = new Date();
-        const startDate = new Date(booking.startDate);
-        const timeDifferenceMs = startDate.getTime() - now.getTime();
+        const endDate = new Date(booking.endDate);
+        const timeDifferenceMs = endDate.getTime() - now.getTime();
         const timeDifferenceHours = timeDifferenceMs / (1000 * 60 * 60);
 
-        return timeDifferenceHours >= 48;
+        return timeDifferenceHours >= 24;
+      } else {
+        return true;
       }
-
-      return false;
     } catch (error) {
       console.error(
         "BookingUtils canCancelBooking error: Errore nel verificare la possibilità di cancellazione:",


### PR DESCRIPTION
aggiornati sia gli enums (canDeleteBooking modificati i termini di calcolo del tempo) che i controlli nell'API per i bookings. Modificati i controlli per il badge status ( problema riscontrato: se la prenotazione è stata annullata ma non è stata pagata, per  come era scritto il ternario precedentemente il badge avrebbe dato sempre stato "da pagare" )